### PR TITLE
Added support for omitted consecutive types

### DIFF
--- a/examples/example1.gen.go
+++ b/examples/example1.gen.go
@@ -50,3 +50,7 @@ func (t *tracingFoo) IsValid() (_result1 bool) {
 func (t *tracingFoo) ValidateMulti(_param1 ...Entity) {
 	t.s.ValidateMulti(_param1...)
 }
+
+func (t *tracingFoo) Multi(p1 string, p2 string) (r1 string, r2 string) {
+	return t.s.Multi(p1, p2)
+}

--- a/examples/example2.gen.go
+++ b/examples/example2.gen.go
@@ -50,3 +50,11 @@ func (l *loggerFoo) ValidateMulti(_param1 ...Entity) {
 	}(time.Now())
 	l.s.ValidateMulti(_param1...)
 }
+
+func (l *loggerFoo) Multi(p1 string, p2 string) (r1 string, r2 string) {
+	defer func(begin time.Time) {
+		var err error
+		log.Print("method", "multi", "took", time.Since(begin), "error", err)
+	}(time.Now())
+	return l.s.Multi(p1, p2)
+}

--- a/examples/interface.go
+++ b/examples/interface.go
@@ -11,4 +11,5 @@ type Foo interface {
 	Save([]Entity) error
 	IsValid() bool
 	ValidateMulti(...Entity)
+	Multi(p1, p2 string) (r1, r2 string)
 }

--- a/parse.go
+++ b/parse.go
@@ -159,31 +159,53 @@ func parseType(pkg string, arg ast.Expr) (Type, error) {
 func parseFunc(pkg string, name string, f *ast.FuncType) (*Method, error) {
 	var method = &Method{Name: name, In: make([]*Parameter, 0), Out: make([]*Parameter, 0)}
 	if f.Params != nil {
-		for idx, arg := range f.Params.List {
-			var param = &Parameter{Name: fmt.Sprintf("_param%d", idx+1)}
-			if len(arg.Names) > 0 {
-				param.Name = arg.Names[0].String()
-			}
+		var index int
+		for _, arg := range f.Params.List {
 			var t, e = parseType(pkg, arg.Type)
 			if e != nil {
 				return nil, e
 			}
-			param.Type = t
-			method.In = append(method.In, param)
+
+			if len(arg.Names) > 0 {
+				for i := range arg.Names {
+					index++
+					method.In = append(method.In, &Parameter{
+						Name: arg.Names[i].String(),
+						Type: t,
+					})
+				}
+			} else {
+				index++
+				method.In = append(method.In, &Parameter{
+					Name: fmt.Sprintf("_param%d", index),
+					Type: t,
+				})
+			}
 		}
 	}
 	if f.Results != nil {
-		for idx, arg := range f.Results.List {
-			var param = &Parameter{Name: fmt.Sprintf("_result%d", idx+1)}
-			if len(arg.Names) > 0 {
-				param.Name = arg.Names[0].String()
-			}
+		var index int
+		for _, arg := range f.Results.List {
 			var t, e = parseType(pkg, arg.Type)
 			if e != nil {
 				return nil, e
 			}
-			param.Type = t
-			method.Out = append(method.Out, param)
+
+			if len(arg.Names) > 0 {
+				for i := range arg.Names {
+					index++
+					method.Out = append(method.Out, &Parameter{
+						Name: arg.Names[i].String(),
+						Type: t,
+					})
+				}
+			} else {
+				index++
+				method.Out = append(method.Out, &Parameter{
+					Name: fmt.Sprintf("_result%d", index),
+					Type: t,
+				})
+			}
 		}
 	}
 	return method, nil

--- a/parse_test.go
+++ b/parse_test.go
@@ -66,6 +66,7 @@ package foo
 
 type Service interface {
 	Foo(string) Bar
+	Mult(p1, p2 string) (r1, r2 string)
 }
 
 `),
@@ -100,6 +101,29 @@ type Service interface {
 									Package: "foo",
 									Type:    TypeBuiltin("Bar"),
 								},
+							},
+						},
+					},
+					&Method{
+						Name: "Mult",
+						In: []*Parameter{
+							&Parameter{
+								Name: "p1",
+								Type: TypeBuiltin("string"),
+							},
+							&Parameter{
+								Name: "p2",
+								Type: TypeBuiltin("string"),
+							},
+						},
+						Out: []*Parameter{
+							&Parameter{
+								Name: "r1",
+								Type: TypeBuiltin("string"),
+							},
+							&Parameter{
+								Name: "r2",
+								Type: TypeBuiltin("string"),
 							},
 						},
 					},


### PR DESCRIPTION
 I'm not sure what the technical term is, but I've added support for omitting consecutive types:
```go
Concat(a, b string) string
Split(str string) (p1, p2 string)
Something(p1, p2 string) (r1, r2 string)
```